### PR TITLE
DCT: Tear down MMS+default connections raised by config_enable_mms_wi…

### DIFF
--- a/src/java/com/android/internal/telephony/dataconnection/DcTracker.java
+++ b/src/java/com/android/internal/telephony/dataconnection/DcTracker.java
@@ -1702,6 +1702,9 @@ public class DcTracker extends DcTrackerBase {
                 // those requests and not torn down organically.
                 if ((apnContext.getApnType() == PhoneConstants.APN_TYPE_DUN && teardownForDun())
                         || apnContext.getState() != DctConstants.State.CONNECTED
+                        || (ConfigResourceUtil.getBooleanValue(mPhone.getContext(),
+                               "config_enable_mms_with_mobile_data_off") &&
+                            apnContext.getApnType().equals(PhoneConstants.APN_TYPE_MMS))
                         || mPhone.getSubId() != SubscriptionManager.getDefaultDataSubId() ) {
                     cleanup = true;
                 } else {


### PR DESCRIPTION
…th_mobile_data_off

If the tracker lets an MMS connection go through even if data is off, make sure
it's torn down once the disabled state gets applied. More often than not, APNs
configured as MMS+data would remain alive, and the tracker's state machine would
get stuck out of sync

Ref: CYNGNOS-3239

Change-Id: Ia13e9ff5beea44ecfda40a4910990dab53af25dd